### PR TITLE
FIX(product-card): Remove opacity from color block, when product not available

### DIFF
--- a/src/shared-components/ProductCard/ProductCard.scss
+++ b/src/shared-components/ProductCard/ProductCard.scss
@@ -21,7 +21,7 @@
     }
     &.out-of-stock{
         .product-card {
-            &__sales-text, &__slider-link, &__content {
+            &__sales-text, &__slider-link, &__title, &__description {
                 opacity: 40%;
             }
             &__favorite {


### PR DESCRIPTION
Jira: [[FE]The product preview "Lotus Chair" shows two gray colors.](https://cozyhometeam.atlassian.net/browse/CH-729)